### PR TITLE
RESETED fix: Duplicate username user creation

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -57,6 +57,12 @@ class UserService:
             if existing_user:
                 logger.error("User with given email already exists.")
                 return None
+
+            existing_user = await cls.get_by_nickname(session, validated_data['nickname'])
+            if existing_user:
+                logger.error("User with given nickname already exists.")
+                return None
+
             validated_data['hashed_password'] = hash_password(validated_data.pop('password'))
             new_user = User(**validated_data)
             new_user.verification_token = generate_verification_token()

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -27,6 +27,26 @@ async def test_create_user_with_invalid_data(db_session, email_service):
     user = await UserService.create(db_session, user_data, email_service)
     assert user is None
 
+
+async def test_duplicate_username(db_session, email_service):
+    # First, create a user
+    user_data = {
+        "email": "duplicate_test@example.com",
+        "password": "ValidPassword123!",
+    }
+    user = await UserService.create(db_session, user_data, email_service)
+    assert user is not None
+    assert user.email == user_data["email"]
+
+    # Try to create another user with the same email
+    duplicate_user_data = {
+        "email": "duplicate_test@example.com",
+        "password": "DifferentPassword456!",
+    }
+
+    user = await UserService.create(db_session, duplicate_user_data, email_service)
+    assert user is  None
+
 # Test fetching a user by ID when the user exists
 async def test_get_by_id_user_exists(db_session, user):
     retrieved_user = await UserService.get_by_id(db_session, user.id)


### PR DESCRIPTION
Users with duplicate username are identified and not created.
Closes #5 