### PR TITLE
fix(dependencies): remove try/except around yield in get_db

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -21,11 +21,7 @@ async def get_db() -> AsyncSession:
     """Dependency that provides a database session for each request."""
     async_session_factory = Database.get_session_factory()
     async with async_session_factory() as session:
-        try:
-            yield session
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=str(e))
-        
+        yield session
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/login")
 


### PR DESCRIPTION
The try/except around yield caused HTTPException from routes in user_routes.py which depended on get_db to not return the correct status codes. This error fixes it. 