### PR TITLE
fix(user): preserve user-supplied nickname and add test to verify behavior

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -50,25 +50,36 @@ class UserService:
         return await cls._fetch_user(session, email=email)
 
     @classmethod
-    async def create(cls, session: AsyncSession, user_data: Dict[str, str], email_service: EmailService) -> Optional[User]:
+    async def create(cls, session: AsyncSession, user_data: Dict[str, str], email_service: EmailService) -> Optional[
+        User]:
         try:
             validated_data = UserCreate(**user_data).model_dump()
+
             existing_user = await cls.get_by_email(session, validated_data['email'])
             if existing_user:
                 logger.error("User with given email already exists.")
                 return None
+
             validated_data['hashed_password'] = hash_password(validated_data.pop('password'))
+
+            nickname = validated_data.get("nickname")
+            if not nickname:
+                new_nickname = generate_nickname()
+                while await cls.get_by_nickname(session, new_nickname):
+                    new_nickname = generate_nickname()
+                validated_data["nickname"] = new_nickname
+            else:
+                if await cls.get_by_nickname(session, nickname):
+                    logger.error(f"Nickname '{nickname}' is already taken.")
+                    return None
+
             new_user = User(**validated_data)
             new_user.verification_token = generate_verification_token()
-            new_nickname = generate_nickname()
-            while await cls.get_by_nickname(session, new_nickname):
-                new_nickname = generate_nickname()
-            new_user.nickname = new_nickname
             session.add(new_user)
             await session.commit()
             await email_service.send_verification_email(new_user)
-            
             return new_user
+
         except ValidationError as e:
             logger.error(f"Validation error during user creation: {e}")
             return None

--- a/tests/test_services/test_user_service_create.py
+++ b/tests/test_services/test_user_service_create.py
@@ -1,0 +1,15 @@
+from app.services.user_service import UserService
+
+
+async def test_provided_nickname_is_preserved(db_session, email_service):
+    original_nickname = "custom_nickname_123"
+    user_data = {
+        "email": "john.unique@example.com",
+        "password": "ValidPass123!",
+        "nickname": original_nickname,
+    }
+
+    user = await UserService.create(db_session, user_data, email_service)
+
+    assert user is not None, "User creation failed unexpectedly"
+    assert user.nickname == original_nickname, f"Expected nickname '{original_nickname}', got '{user.nickname}'"


### PR DESCRIPTION
Updated UserService.create to retain the nickname provided by the user if present and unique. A new nickname is only generated when none is supplied. Added a test to ensure that user-supplied nicknames are not overridden during registration.